### PR TITLE
[#4] Correct Read the Docs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,8 @@ version: 2
 python:
     version: 3.6
     install:
-          path: .
+      - method: setuptools
+        path: .
     system_packages: true
 
 sphinx:


### PR DESCRIPTION
Current Python install of the Read the Docs configuration is not valid.